### PR TITLE
`Overview.md`: use mermaid syntax

### DIFF
--- a/Overview.md
+++ b/Overview.md
@@ -16,7 +16,37 @@ The functional abstractions in `@fp-ts/core` can be broadly divided into two cat
 
 # Parameterized Types
 
-![Type Class Hierarchy](typeclass.png "Type Class Hierarchy")
+### Type Class Hierarchy
+
+```mermaid
+flowchart TD
+    Alternative --> NonEmptyAlternative
+    Alternative --> Coproduct
+    Applicative --> Product
+    Coproduct --> NonEmptyCoproduct
+    NonEmptyAlternative --> Covariant
+    NonEmptyAlternative --> NonEmptyCoproduct
+    NonEmptyApplicative --> NonEmptyProduct
+    NonEmptyApplicative --> Covariant
+    Applicative --> NonEmptyApplicative
+    Comonad --> Extendable
+    Extendable --> Covariant
+    Chainable --> FlatMap
+    Chainable ---> Covariant
+    Monad --> Pointed
+    Monad --> FlatMap
+    Pointed --> Of
+    Pointed --> Covariant
+    Product --> NonEmptyProduct
+    Product --> Of
+    NonEmptyProduct --> Invariant
+    Covariant --> Invariant
+    Contravariant --> Invariant
+```
+
+### All available typeclasses
+
+Note: some of these are omitted from the diagram above because they do not extend any functionality.
 
 |                           | member(s)                                     | extends                                |
 | ------------------------- | --------------------------------------------- | -------------------------------------- |
@@ -27,7 +57,7 @@ The functional abstractions in `@fp-ts/core` can be broadly divided into two cat
 | **Comonad**               | `extract`                                     | **Extendable**                         |
 | **Compactable**           | `compact`                                     |                                        |
 | **Contravariant**         | `contramap`                                   | **Invariant**                          |
-| **Coproduct**             | `zero`<br>`coproductAll`                      |                                        |
+| **Coproduct**             | `zero`<br>`coproductAll`                      | **NonEmptyCoproduct**                  |
 | **Covariant**             | `map`                                         | **Invariant**                          |
 | **Extendable**            | `extend`                                      | **Covariant**                          |
 | **Filterable**            | `filterMap`                                   |                                        |


### PR DESCRIPTION
GitHub recently added built-in support for [Mermaid.js](https://mermaid-js.github.io/) in markdown files.

I totally understand if the authors would prefer to keep the .png, but this is a pretty nice way to keep documentation in sync without the necessity of external tools to generate image assets.

Also in this PR:
1. Added some additional wording, which could probably use additional review.
2. Added `NonEmptyCoproduct` to the `extends` column for `Coproduct`.


Here's the rendered preview: [link](https://github.com/newswim/core/blob/9bc5cf9e38508a1242e7e5af3358a63f3e935d0d/Overview.md)
Here's an editable preview: [link](https://mermaid.live/edit#pako:eNqNk8FvgjAYxf8V8p3RCILQHpYs6pId3Ei208LlG62zGbSkK05n_N_HGCggi-PUvvfjvbbQAySKcaCwTtVnskFtrOdFLK3yuU0N1xKN2HJrNLqxHpRcZrnZt_RhcK5yrViRmNrO81QkZztqmye2U9FLGGiui7aoBcor2LXU3voaPfoP3FvCX1ktvdl3piSyClruDJcMX9PaO8-HKuYbFPJk3qVoVphfWpcvrk6FkRLScNaXO1k1UxmP60utFx4NfMXOAbaBJq8HVt697O62qRk2pdE4CIANGdcZClb-24cfPAaz4RmPgZZDhvo9hlgeSw4Lo572MgFqdMFtKHKGhi8EvmnMgK4x_SjVHOWLUp050APsgDouGc9CfzLzXScIPMf3bNgD9aZj4nth6LiTMCCuQ_yjDV9VxGQcBlPiBl5IXEK8gNjAmTBKr37vYnUlj98GeCsO).