### PR TITLE
feat: extendes flip to support functions with muliple arguments

### DIFF
--- a/src/Function.ts
+++ b/src/Function.ts
@@ -170,8 +170,9 @@ export const constVoid: LazyArg<void> = constUndefined
  *
  * @since 1.0.0
  */
-export const flip = <A, B, C>(f: (a: A) => (b: B) => C): ((b: B) => (a: A) => C) =>
-  (b) => (a) => f(a)(b)
+export const flip = <A extends Array<unknown>, B extends Array<unknown>, C>(
+  f: (...a: A) => (...b: B) => C
+): ((...b: B) => (...a: A) => C) => (...b) => (...a) => f(...a)(...b)
 
 /**
  * Performs left-to-right function composition. The first argument may have any arity, the remaining arguments must be unary.

--- a/test/Function.ts
+++ b/test/Function.ts
@@ -36,7 +36,10 @@ describe.concurrent("Function", () => {
 
   it("flip", () => {
     const f = (a: number) => (b: string) => a - b.length
+    const g = (a: number, i = 0) => (b: number) => a ** b + i
+
     deepStrictEqual(Function.flip(f)("aaa")(2), -1)
+    deepStrictEqual(Function.flip(g)(2)(2, 1), 5)
   })
 
   it("compose", () => {


### PR DESCRIPTION
Extends `flip` to handle functions with multiple arguments