### PR TITLE
feat: extended apply and compose functions

### DIFF
--- a/src/Function.ts
+++ b/src/Function.ts
@@ -20,7 +20,7 @@ export interface FunctionTypeLambda extends TypeLambda {
 /**
  * @since 1.0.0
  */
-export const compose: <B, C>(bc: (b: B) => C) => <A>(ab: (a: A) => B) => (a: A) => C = (bc) =>
+export const compose: <B, C>(bc: (b: B) => C) => <A extends ReadonlyArray<unknown>>(ab: (...a: A) => B) => (...a: A) => C = (bc) =>
   (ab) => flow(ab, bc)
 
 /**
@@ -85,7 +85,7 @@ export const getMonoid = <M>(Monoid: monoid.Monoid<M>) =>
 /**
  * @since 1.0.0
  */
-export const apply = <A>(a: A) => <B>(self: (a: A) => B): B => self(a)
+export const apply = <A extends ReadonlyArray<unknown>>(...a: A) => <B>(self: (...a: A) => B): B => self(...a)
 
 /**
  * A lazy argument

--- a/src/Function.ts
+++ b/src/Function.ts
@@ -20,7 +20,9 @@ export interface FunctionTypeLambda extends TypeLambda {
 /**
  * @since 1.0.0
  */
-export const compose: <B, C>(bc: (b: B) => C) => <A extends ReadonlyArray<unknown>>(ab: (...a: A) => B) => (...a: A) => C = (bc) =>
+export const compose: <B, C>(
+  bc: (b: B) => C
+) => <A extends ReadonlyArray<unknown>>(ab: (...a: A) => B) => (...a: A) => C = (bc) =>
   (ab) => flow(ab, bc)
 
 /**
@@ -85,7 +87,8 @@ export const getMonoid = <M>(Monoid: monoid.Monoid<M>) =>
 /**
  * @since 1.0.0
  */
-export const apply = <A extends ReadonlyArray<unknown>>(...a: A) => <B>(self: (...a: A) => B): B => self(...a)
+export const apply = <A extends ReadonlyArray<unknown>>(...a: A) =>
+  <B>(self: (...a: A) => B): B => self(...a)
 
 /**
  * A lazy argument

--- a/test/Function.ts
+++ b/test/Function.ts
@@ -6,6 +6,7 @@ import * as assert from "assert"
 
 const f = (n: number): number => n + 1
 const g = double
+const sum = (a: number, b: number): number => a + b
 
 describe.concurrent("Function", () => {
   it("getSemigroup", () => {
@@ -32,6 +33,7 @@ describe.concurrent("Function", () => {
 
   it("apply", () => {
     deepStrictEqual(Function.apply("a")(String.length), 1)
+    deepStrictEqual(Function.apply(1, 2)(sum), 3)
   })
 
   it("flip", () => {
@@ -44,6 +46,7 @@ describe.concurrent("Function", () => {
 
   it("compose", () => {
     deepStrictEqual(Function.pipe(String.length, Function.compose(double))("aaa"), 6)
+    deepStrictEqual(Function.pipe(sum, Function.compose(double))(1, 2), 6)
   })
 
   it("unsafeCoerce", () => {


### PR DESCRIPTION
Extends Function/apply and Function/compose functions to support functions with multiple arguments. Also, the flip function should probably be implemented using higher kinded types in order to support functions like `<A>(...a: A) => <B>(...b: B) => C` without loosing type information but I have not idea how to actually do this. jaja