### PR TITLE
Add missing boolean combinators

### DIFF
--- a/.changeset/mighty-meals-dream.md
+++ b/.changeset/mighty-meals-dream.md
@@ -1,0 +1,5 @@
+---
+"@fp-ts/core": minor
+---
+
+add missing boolean semigroups, monoids and combinators

--- a/docs/modules/Boolean.ts.md
+++ b/docs/modules/Boolean.ts.md
@@ -36,6 +36,7 @@ Added in v1.0.0
   - [Order](#order)
   - [SemigroupAll](#semigroupall)
   - [SemigroupAny](#semigroupany)
+  - [SemigroupEqv](#semigroupeqv)
   - [SemigroupXor](#semigroupxor)
 - [pattern matching](#pattern-matching)
   - [match](#match)
@@ -274,9 +275,32 @@ assert.deepStrictEqual(SemigroupAny.combine(false, false), false)
 
 Added in v1.0.0
 
+## SemigroupEqv
+
+`boolean` semigroup under equivalence.
+
+**Signature**
+
+```ts
+export declare const SemigroupEqv: semigroup.Semigroup<boolean>
+```
+
+**Example**
+
+```ts
+import { SemigroupEqv } from '@fp-ts/core/Boolean'
+
+assert.deepStrictEqual(SemigroupEqv.combine(true, true), true)
+assert.deepStrictEqual(SemigroupEqv.combine(true, false), false)
+assert.deepStrictEqual(SemigroupEqv.combine(false, true), false)
+assert.deepStrictEqual(SemigroupEqv.combine(false, false), true)
+```
+
+Added in v1.0.0
+
 ## SemigroupXor
 
-`boolean` semigroup under disjunction.
+`boolean` semigroup under exclusive disjunction.
 
 **Signature**
 

--- a/docs/modules/Boolean.ts.md
+++ b/docs/modules/Boolean.ts.md
@@ -18,8 +18,13 @@ Added in v1.0.0
 
 - [combinators](#combinators)
   - [and](#and)
+  - [implies](#implies)
+  - [nand](#nand)
+  - [nor](#nor)
   - [not](#not)
   - [or](#or)
+  - [xnor](#xnor)
+  - [xor](#xor)
 - [guards](#guards)
   - [isBoolean](#isboolean)
 - [instances](#instances)
@@ -29,6 +34,7 @@ Added in v1.0.0
   - [Order](#order)
   - [SemigroupAll](#semigroupall)
   - [SemigroupAny](#semigroupany)
+  - [SemigroupExclusiveAny](#semigroupexclusiveany)
 - [pattern matching](#pattern-matching)
   - [match](#match)
 - [utils](#utils)
@@ -49,6 +55,36 @@ export declare const and: { (that: boolean): (self: boolean) => boolean; (self: 
 
 Added in v1.0.0
 
+## implies
+
+**Signature**
+
+```ts
+export declare const implies: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
+```
+
+Added in v1.0.0
+
+## nand
+
+**Signature**
+
+```ts
+export declare const nand: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
+```
+
+Added in v1.0.0
+
+## nor
+
+**Signature**
+
+```ts
+export declare const nor: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
+```
+
+Added in v1.0.0
+
 ## not
 
 **Signature**
@@ -65,6 +101,26 @@ Added in v1.0.0
 
 ```ts
 export declare const or: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
+```
+
+Added in v1.0.0
+
+## xnor
+
+**Signature**
+
+```ts
+export declare const xnor: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
+```
+
+Added in v1.0.0
+
+## xor
+
+**Signature**
+
+```ts
+export declare const xor: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
 ```
 
 Added in v1.0.0
@@ -156,10 +212,11 @@ export declare const SemigroupAll: semigroup.Semigroup<boolean>
 
 ```ts
 import { SemigroupAll } from '@fp-ts/core/Boolean'
-import { pipe } from '@fp-ts/core/Function'
 
 assert.deepStrictEqual(SemigroupAll.combine(true, true), true)
 assert.deepStrictEqual(SemigroupAll.combine(true, false), false)
+assert.deepStrictEqual(SemigroupAll.combine(false, true), false)
+assert.deepStrictEqual(SemigroupAll.combine(false, false), false)
 ```
 
 Added in v1.0.0
@@ -178,11 +235,34 @@ export declare const SemigroupAny: semigroup.Semigroup<boolean>
 
 ```ts
 import { SemigroupAny } from '@fp-ts/core/Boolean'
-import { pipe } from '@fp-ts/core/Function'
 
 assert.deepStrictEqual(SemigroupAny.combine(true, true), true)
 assert.deepStrictEqual(SemigroupAny.combine(true, false), true)
+assert.deepStrictEqual(SemigroupAny.combine(false, true), true)
 assert.deepStrictEqual(SemigroupAny.combine(false, false), false)
+```
+
+Added in v1.0.0
+
+## SemigroupExclusiveAny
+
+`boolean` semigroup under disjunction.
+
+**Signature**
+
+```ts
+export declare const SemigroupExclusiveAny: semigroup.Semigroup<boolean>
+```
+
+**Example**
+
+```ts
+import { SemigroupExclusiveAny } from '@fp-ts/core/Boolean'
+
+assert.deepStrictEqual(SemigroupExclusiveAny.combine(true, true), false)
+assert.deepStrictEqual(SemigroupExclusiveAny.combine(true, false), true)
+assert.deepStrictEqual(SemigroupExclusiveAny.combine(false, true), true)
+assert.deepStrictEqual(SemigroupExclusiveAny.combine(false, false), false)
 ```
 
 Added in v1.0.0

--- a/docs/modules/Boolean.ts.md
+++ b/docs/modules/Boolean.ts.md
@@ -18,12 +18,12 @@ Added in v1.0.0
 
 - [combinators](#combinators)
   - [and](#and)
+  - [eqv](#eqv)
   - [implies](#implies)
   - [nand](#nand)
   - [nor](#nor)
   - [not](#not)
   - [or](#or)
-  - [xnor](#xnor)
   - [xor](#xor)
 - [guards](#guards)
   - [isBoolean](#isboolean)
@@ -31,6 +31,8 @@ Added in v1.0.0
   - [Equivalence](#equivalence)
   - [MonoidAll](#monoidall)
   - [MonoidAny](#monoidany)
+  - [MonoidEqv](#monoideqv)
+  - [MonoidXor](#monoidxor)
   - [Order](#order)
   - [SemigroupAll](#semigroupall)
   - [SemigroupAny](#semigroupany)
@@ -51,6 +53,16 @@ Added in v1.0.0
 
 ```ts
 export declare const and: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
+```
+
+Added in v1.0.0
+
+## eqv
+
+**Signature**
+
+```ts
+export declare const eqv: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
 ```
 
 Added in v1.0.0
@@ -101,16 +113,6 @@ Added in v1.0.0
 
 ```ts
 export declare const or: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
-```
-
-Added in v1.0.0
-
-## xnor
-
-**Signature**
-
-```ts
-export declare const xnor: { (that: boolean): (self: boolean) => boolean; (self: boolean, that: boolean): boolean }
 ```
 
 Added in v1.0.0
@@ -184,6 +186,34 @@ The `empty` value is `false`.
 
 ```ts
 export declare const MonoidAny: monoid.Monoid<boolean>
+```
+
+Added in v1.0.0
+
+## MonoidEqv
+
+`boolean` monoid under equivalence.
+
+The `empty` value is `true`.
+
+**Signature**
+
+```ts
+export declare const MonoidEqv: monoid.Monoid<boolean>
+```
+
+Added in v1.0.0
+
+## MonoidXor
+
+`boolean` monoid under exclusive disjunction.
+
+The `empty` value is `false`.
+
+**Signature**
+
+```ts
+export declare const MonoidXor: monoid.Monoid<boolean>
 ```
 
 Added in v1.0.0

--- a/docs/modules/Boolean.ts.md
+++ b/docs/modules/Boolean.ts.md
@@ -34,7 +34,7 @@ Added in v1.0.0
   - [Order](#order)
   - [SemigroupAll](#semigroupall)
   - [SemigroupAny](#semigroupany)
-  - [SemigroupExclusiveAny](#semigroupexclusiveany)
+  - [SemigroupXor](#semigroupxor)
 - [pattern matching](#pattern-matching)
   - [match](#match)
 - [utils](#utils)
@@ -244,25 +244,25 @@ assert.deepStrictEqual(SemigroupAny.combine(false, false), false)
 
 Added in v1.0.0
 
-## SemigroupExclusiveAny
+## SemigroupXor
 
 `boolean` semigroup under disjunction.
 
 **Signature**
 
 ```ts
-export declare const SemigroupExclusiveAny: semigroup.Semigroup<boolean>
+export declare const SemigroupXor: semigroup.Semigroup<boolean>
 ```
 
 **Example**
 
 ```ts
-import { SemigroupExclusiveAny } from '@fp-ts/core/Boolean'
+import { SemigroupXor } from '@fp-ts/core/Boolean'
 
-assert.deepStrictEqual(SemigroupExclusiveAny.combine(true, true), false)
-assert.deepStrictEqual(SemigroupExclusiveAny.combine(true, false), true)
-assert.deepStrictEqual(SemigroupExclusiveAny.combine(false, true), true)
-assert.deepStrictEqual(SemigroupExclusiveAny.combine(false, false), false)
+assert.deepStrictEqual(SemigroupXor.combine(true, true), false)
+assert.deepStrictEqual(SemigroupXor.combine(true, false), true)
+assert.deepStrictEqual(SemigroupXor.combine(false, true), true)
+assert.deepStrictEqual(SemigroupXor.combine(false, false), false)
 ```
 
 Added in v1.0.0

--- a/docs/modules/typeclass/Monoid.ts.md
+++ b/docs/modules/typeclass/Monoid.ts.md
@@ -27,6 +27,8 @@ Added in v1.0.0
   - [bigintSum](#bigintsum)
   - [booleanAll](#booleanall)
   - [booleanAny](#booleanany)
+  - [booleanEqv](#booleaneqv)
+  - [booleanXor](#booleanxor)
   - [numberMultiply](#numbermultiply)
   - [numberSum](#numbersum)
   - [string](#string)
@@ -205,6 +207,34 @@ The `empty` value is `false`.
 
 ```ts
 export declare const booleanAny: Monoid<boolean>
+```
+
+Added in v1.0.0
+
+## booleanEqv
+
+`boolean` monoid under equivalence.
+
+The `empty` value is `true`.
+
+**Signature**
+
+```ts
+export declare const booleanEqv: Monoid<boolean>
+```
+
+Added in v1.0.0
+
+## booleanXor
+
+`boolean` monoid under exclusive disjunction.
+
+The `empty` value is `false`.
+
+**Signature**
+
+```ts
+export declare const booleanXor: Monoid<boolean>
 ```
 
 Added in v1.0.0

--- a/docs/modules/typeclass/Semigroup.ts.md
+++ b/docs/modules/typeclass/Semigroup.ts.md
@@ -30,6 +30,7 @@ Added in v1.0.0
   - [bigintSum](#bigintsum)
   - [booleanAll](#booleanall)
   - [booleanAny](#booleanany)
+  - [booleanExclusiveAny](#booleanexclusiveany)
   - [first](#first)
   - [last](#last)
   - [numberMultiply](#numbermultiply)
@@ -233,6 +234,18 @@ Added in v1.0.0
 
 ```ts
 export declare const booleanAny: Semigroup<boolean>
+```
+
+Added in v1.0.0
+
+## booleanExclusiveAny
+
+`boolean` semigroup under exclusive disjunction.
+
+**Signature**
+
+```ts
+export declare const booleanExclusiveAny: Semigroup<boolean>
 ```
 
 Added in v1.0.0

--- a/docs/modules/typeclass/Semigroup.ts.md
+++ b/docs/modules/typeclass/Semigroup.ts.md
@@ -30,6 +30,7 @@ Added in v1.0.0
   - [bigintSum](#bigintsum)
   - [booleanAll](#booleanall)
   - [booleanAny](#booleanany)
+  - [booleanEqv](#booleaneqv)
   - [booleanXor](#booleanxor)
   - [first](#first)
   - [last](#last)
@@ -234,6 +235,18 @@ Added in v1.0.0
 
 ```ts
 export declare const booleanAny: Semigroup<boolean>
+```
+
+Added in v1.0.0
+
+## booleanEqv
+
+`boolean` semigroup under equivalence.
+
+**Signature**
+
+```ts
+export declare const booleanEqv: Semigroup<boolean>
 ```
 
 Added in v1.0.0

--- a/docs/modules/typeclass/Semigroup.ts.md
+++ b/docs/modules/typeclass/Semigroup.ts.md
@@ -30,7 +30,7 @@ Added in v1.0.0
   - [bigintSum](#bigintsum)
   - [booleanAll](#booleanall)
   - [booleanAny](#booleanany)
-  - [booleanExclusiveAny](#booleanexclusiveany)
+  - [booleanXor](#booleanxor)
   - [first](#first)
   - [last](#last)
   - [numberMultiply](#numbermultiply)
@@ -238,14 +238,14 @@ export declare const booleanAny: Semigroup<boolean>
 
 Added in v1.0.0
 
-## booleanExclusiveAny
+## booleanXor
 
 `boolean` semigroup under exclusive disjunction.
 
 **Signature**
 
 ```ts
-export declare const booleanExclusiveAny: Semigroup<boolean>
+export declare const booleanXor: Semigroup<boolean>
 ```
 
 Added in v1.0.0

--- a/src/Boolean.ts
+++ b/src/Boolean.ts
@@ -6,7 +6,7 @@
  * @since 1.0.0
  */
 import type { LazyArg } from "@fp-ts/core/Function"
-import { dual } from "@fp-ts/core/Function"
+import { dual, flow } from "@fp-ts/core/Function"
 import * as predicate from "@fp-ts/core/Predicate"
 import * as equivalence from "@fp-ts/core/typeclass/Equivalence"
 import * as monoid from "@fp-ts/core/typeclass/Monoid"
@@ -76,10 +76,11 @@ export const Order: order.Order<boolean> = order.boolean
  *
  * @example
  * import { SemigroupAll } from '@fp-ts/core/Boolean'
- * import { pipe } from '@fp-ts/core/Function'
  *
  * assert.deepStrictEqual(SemigroupAll.combine(true, true), true)
  * assert.deepStrictEqual(SemigroupAll.combine(true, false), false)
+ * assert.deepStrictEqual(SemigroupAll.combine(false, true), false)
+ * assert.deepStrictEqual(SemigroupAll.combine(false, false), false)
  *
  * @category instances
  * @since 1.0.0
@@ -91,16 +92,32 @@ export const SemigroupAll: semigroup.Semigroup<boolean> = semigroup.booleanAll
  *
  * @example
  * import { SemigroupAny } from '@fp-ts/core/Boolean'
- * import { pipe } from '@fp-ts/core/Function'
  *
  * assert.deepStrictEqual(SemigroupAny.combine(true, true), true)
  * assert.deepStrictEqual(SemigroupAny.combine(true, false), true)
+ * assert.deepStrictEqual(SemigroupAny.combine(false, true), true)
  * assert.deepStrictEqual(SemigroupAny.combine(false, false), false)
  *
  * @category instances
  * @since 1.0.0
  */
 export const SemigroupAny: semigroup.Semigroup<boolean> = semigroup.booleanAny
+
+/**
+ * `boolean` semigroup under disjunction.
+ *
+ * @example
+ * import { SemigroupExclusiveAny } from '@fp-ts/core/Boolean'
+ *
+ * assert.deepStrictEqual(SemigroupExclusiveAny.combine(true, true), false)
+ * assert.deepStrictEqual(SemigroupExclusiveAny.combine(true, false), true)
+ * assert.deepStrictEqual(SemigroupExclusiveAny.combine(false, true), true)
+ * assert.deepStrictEqual(SemigroupExclusiveAny.combine(false, false), false)
+ *
+ * @category instances
+ * @since 1.0.0
+ */
+export const SemigroupExclusiveAny: semigroup.Semigroup<boolean> = semigroup.booleanExclusiveAny
 
 /**
  * `boolean` monoid under conjunction.
@@ -126,10 +143,25 @@ export const MonoidAny: monoid.Monoid<boolean> = monoid.booleanAny
  * @category combinators
  * @since 1.0.0
  */
+export const not = (self: boolean): boolean => !self
+
+/**
+ * @category combinators
+ * @since 1.0.0
+ */
 export const and: {
   (that: boolean): (self: boolean) => boolean
   (self: boolean, that: boolean): boolean
 } = dual(2, semigroup.booleanAll.combine)
+
+/**
+ * @category combinators
+ * @since 1.0.0
+ */
+export const nand: {
+  (that: boolean): (self: boolean) => boolean
+  (self: boolean, that: boolean): boolean
+} = dual(2, flow(semigroup.booleanAll.combine, not))
 
 /**
  * @category combinators
@@ -144,7 +176,37 @@ export const or: {
  * @category combinators
  * @since 1.0.0
  */
-export const not = (self: boolean): boolean => !self
+export const nor: {
+  (that: boolean): (self: boolean) => boolean
+  (self: boolean, that: boolean): boolean
+} = dual(2, flow(semigroup.booleanAny.combine, not))
+
+/**
+ * @category combinators
+ * @since 1.0.0
+ */
+export const xor: {
+  (that: boolean): (self: boolean) => boolean
+  (self: boolean, that: boolean): boolean
+} = dual(2, semigroup.booleanExclusiveAny.combine)
+
+/**
+ * @category combinators
+ * @since 1.0.0
+ */
+export const xnor: {
+  (that: boolean): (self: boolean) => boolean
+  (self: boolean, that: boolean): boolean
+} = dual(2, flow(semigroup.booleanExclusiveAny.combine, not))
+
+/**
+ * @category combinators
+ * @since 1.0.0
+ */
+export const implies: {
+  (that: boolean): (self: boolean) => boolean
+  (self: boolean, that: boolean): boolean
+} = dual(2, (self, that) => self ? that : true)
 
 /**
  * @since 1.0.0

--- a/src/Boolean.ts
+++ b/src/Boolean.ts
@@ -107,17 +107,17 @@ export const SemigroupAny: semigroup.Semigroup<boolean> = semigroup.booleanAny
  * `boolean` semigroup under disjunction.
  *
  * @example
- * import { SemigroupExclusiveAny } from '@fp-ts/core/Boolean'
+ * import { SemigroupXor } from '@fp-ts/core/Boolean'
  *
- * assert.deepStrictEqual(SemigroupExclusiveAny.combine(true, true), false)
- * assert.deepStrictEqual(SemigroupExclusiveAny.combine(true, false), true)
- * assert.deepStrictEqual(SemigroupExclusiveAny.combine(false, true), true)
- * assert.deepStrictEqual(SemigroupExclusiveAny.combine(false, false), false)
+ * assert.deepStrictEqual(SemigroupXor.combine(true, true), false)
+ * assert.deepStrictEqual(SemigroupXor.combine(true, false), true)
+ * assert.deepStrictEqual(SemigroupXor.combine(false, true), true)
+ * assert.deepStrictEqual(SemigroupXor.combine(false, false), false)
  *
  * @category instances
  * @since 1.0.0
  */
-export const SemigroupExclusiveAny: semigroup.Semigroup<boolean> = semigroup.booleanExclusiveAny
+export const SemigroupXor: semigroup.Semigroup<boolean> = semigroup.booleanXor
 
 /**
  * `boolean` monoid under conjunction.
@@ -188,7 +188,7 @@ export const nor: {
 export const xor: {
   (that: boolean): (self: boolean) => boolean
   (self: boolean, that: boolean): boolean
-} = dual(2, semigroup.booleanExclusiveAny.combine)
+} = dual(2, semigroup.booleanXor.combine)
 
 /**
  * @category combinators
@@ -197,7 +197,7 @@ export const xor: {
 export const xnor: {
   (that: boolean): (self: boolean) => boolean
   (self: boolean, that: boolean): boolean
-} = dual(2, flow(semigroup.booleanExclusiveAny.combine, not))
+} = dual(2, flow(semigroup.booleanXor.combine, not))
 
 /**
  * @category combinators

--- a/src/Boolean.ts
+++ b/src/Boolean.ts
@@ -140,6 +140,26 @@ export const MonoidAll: monoid.Monoid<boolean> = monoid.booleanAll
 export const MonoidAny: monoid.Monoid<boolean> = monoid.booleanAny
 
 /**
+ * `boolean` monoid under exclusive disjunction.
+ *
+ * The `empty` value is `false`.
+ *
+ * @category instances
+ * @since 1.0.0
+ */
+export const MonoidXor: monoid.Monoid<boolean> = monoid.booleanXor
+
+/**
+ * `boolean` monoid under equivalence.
+ *
+ * The `empty` value is `true`.
+ *
+ * @category instances
+ * @since 1.0.0
+ */
+export const MonoidEqv: monoid.Monoid<boolean> = monoid.booleanEqv
+
+/**
  * @category combinators
  * @since 1.0.0
  */
@@ -194,10 +214,10 @@ export const xor: {
  * @category combinators
  * @since 1.0.0
  */
-export const xnor: {
+export const eqv: {
   (that: boolean): (self: boolean) => boolean
   (self: boolean, that: boolean): boolean
-} = dual(2, flow(semigroup.booleanXor.combine, not))
+} = dual(2, semigroup.booleanEqv.combine)
 
 /**
  * @category combinators

--- a/src/Boolean.ts
+++ b/src/Boolean.ts
@@ -104,7 +104,7 @@ export const SemigroupAll: semigroup.Semigroup<boolean> = semigroup.booleanAll
 export const SemigroupAny: semigroup.Semigroup<boolean> = semigroup.booleanAny
 
 /**
- * `boolean` semigroup under disjunction.
+ * `boolean` semigroup under exclusive disjunction.
  *
  * @example
  * import { SemigroupXor } from '@fp-ts/core/Boolean'
@@ -118,6 +118,21 @@ export const SemigroupAny: semigroup.Semigroup<boolean> = semigroup.booleanAny
  * @since 1.0.0
  */
 export const SemigroupXor: semigroup.Semigroup<boolean> = semigroup.booleanXor
+/**
+ * `boolean` semigroup under equivalence.
+ *
+ * @example
+ * import { SemigroupEqv } from '@fp-ts/core/Boolean'
+ *
+ * assert.deepStrictEqual(SemigroupEqv.combine(true, true), true)
+ * assert.deepStrictEqual(SemigroupEqv.combine(true, false), false)
+ * assert.deepStrictEqual(SemigroupEqv.combine(false, true), false)
+ * assert.deepStrictEqual(SemigroupEqv.combine(false, false), true)
+ *
+ * @category instances
+ * @since 1.0.0
+ */
+export const SemigroupEqv: semigroup.Semigroup<boolean> = semigroup.booleanEqv
 
 /**
  * `boolean` monoid under conjunction.

--- a/src/typeclass/Monoid.ts
+++ b/src/typeclass/Monoid.ts
@@ -120,6 +120,26 @@ export const booleanAll: Monoid<boolean> = fromSemigroup(semigroup.booleanAll, t
 export const booleanAny: Monoid<boolean> = fromSemigroup(semigroup.booleanAny, false)
 
 /**
+ * `boolean` monoid under exclusive disjunction.
+ *
+ * The `empty` value is `false`.
+ *
+ * @category instances
+ * @since 1.0.0
+ */
+export const booleanXor: Monoid<boolean> = fromSemigroup(semigroup.booleanXor, false)
+
+/**
+ * `boolean` monoid under equivalence.
+ *
+ * The `empty` value is `true`.
+ *
+ * @category instances
+ * @since 1.0.0
+ */
+export const booleanEqv: Monoid<boolean> = fromSemigroup(semigroup.booleanEqv, true)
+
+/**
  * This function creates and returns a new `Monoid` for a tuple of values based on the given `Monoid`s for each element in the tuple.
  * The returned `Monoid` combines two tuples of the same type by applying the corresponding `Monoid` passed as arguments to each element in the tuple.
  *

--- a/src/typeclass/Semigroup.ts
+++ b/src/typeclass/Semigroup.ts
@@ -157,21 +157,7 @@ export const booleanAny: Semigroup<boolean> = make(
  * @category instances
  * @since 1.0.0
  */
-export const booleanXor: Semigroup<boolean> = make(
-  (self, that) => self !== that,
-  (self, collection) => {
-    let isEmptyIterable = true
-    for (const b of collection) {
-      if (isEmptyIterable) {
-        isEmptyIterable = false
-      }
-      if (b !== self) {
-        return true
-      }
-    }
-    return isEmptyIterable ? self : false
-  }
-)
+export const booleanXor: Semigroup<boolean> = make((self, that) => self !== that)
 
 /**
  * This function creates and returns a new `Semigroup` for a tuple of values based on the given `Semigroup`s for each element in the tuple.

--- a/src/typeclass/Semigroup.ts
+++ b/src/typeclass/Semigroup.ts
@@ -152,6 +152,28 @@ export const booleanAny: Semigroup<boolean> = make(
 )
 
 /**
+ * `boolean` semigroup under exclusive disjunction.
+ *
+ * @category instances
+ * @since 1.0.0
+ */
+export const booleanExclusiveAny: Semigroup<boolean> = make(
+  (self, that) => self !== that,
+  (self, collection) => {
+    let isEmptyIterable = true
+    for (const b of collection) {
+      if (isEmptyIterable) {
+        isEmptyIterable = false
+      }
+      if (b !== self) {
+        return true
+      }
+    }
+    return isEmptyIterable ? self : false
+  }
+)
+
+/**
  * This function creates and returns a new `Semigroup` for a tuple of values based on the given `Semigroup`s for each element in the tuple.
  * The returned `Semigroup` combines two tuples of the same type by applying the corresponding `Semigroup` passed as arguments to each element in the tuple.
  *

--- a/src/typeclass/Semigroup.ts
+++ b/src/typeclass/Semigroup.ts
@@ -157,7 +157,7 @@ export const booleanAny: Semigroup<boolean> = make(
  * @category instances
  * @since 1.0.0
  */
-export const booleanExclusiveAny: Semigroup<boolean> = make(
+export const booleanXor: Semigroup<boolean> = make(
   (self, that) => self !== that,
   (self, collection) => {
     let isEmptyIterable = true

--- a/src/typeclass/Semigroup.ts
+++ b/src/typeclass/Semigroup.ts
@@ -160,6 +160,14 @@ export const booleanAny: Semigroup<boolean> = make(
 export const booleanXor: Semigroup<boolean> = make((self, that) => self !== that)
 
 /**
+ * `boolean` semigroup under equivalence.
+ *
+ * @category instances
+ * @since 1.0.0
+ */
+export const booleanEqv: Semigroup<boolean> = make((self, that) => self === that)
+
+/**
  * This function creates and returns a new `Semigroup` for a tuple of values based on the given `Semigroup`s for each element in the tuple.
  * The returned `Semigroup` combines two tuples of the same type by applying the corresponding `Semigroup` passed as arguments to each element in the tuple.
  *

--- a/test/Boolean.ts
+++ b/test/Boolean.ts
@@ -55,11 +55,11 @@ describe.concurrent("Boolean", () => {
     deepStrictEqual(pipe(false, Boolean.xor(false)), false)
   })
 
-  it("xnor", () => {
-    deepStrictEqual(pipe(true, Boolean.xnor(true)), true)
-    deepStrictEqual(pipe(true, Boolean.xnor(false)), false)
-    deepStrictEqual(pipe(false, Boolean.xnor(true)), false)
-    deepStrictEqual(pipe(false, Boolean.xnor(false)), true)
+  it("eqv", () => {
+    deepStrictEqual(pipe(true, Boolean.eqv(true)), true)
+    deepStrictEqual(pipe(true, Boolean.eqv(false)), false)
+    deepStrictEqual(pipe(false, Boolean.eqv(true)), false)
+    deepStrictEqual(pipe(false, Boolean.eqv(false)), true)
   })
 
   it("implies", () => {
@@ -74,16 +74,45 @@ describe.concurrent("Boolean", () => {
     deepStrictEqual(pipe(false, Boolean.not), true)
   })
 
-  describe.concurrent("SemigroupXor", () => {
+  describe.concurrent("MonoidXor", () => {
     it("baseline", () => {
-      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, []), true)
-      deepStrictEqual(Boolean.SemigroupXor.combineMany(false, []), false)
-      deepStrictEqual(Boolean.SemigroupXor.combineMany(false, [true]), true)
-      deepStrictEqual(Boolean.SemigroupXor.combineMany(false, [false]), false)
-      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [true]), false)
-      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [false]), true)
-      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [true, false]), false)
-      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [false, true]), false)
+      deepStrictEqual(Boolean.MonoidXor.combineMany(true, []), true)
+      deepStrictEqual(Boolean.MonoidXor.combineMany(false, []), false)
+      deepStrictEqual(Boolean.MonoidXor.combineMany(false, [true]), true)
+      deepStrictEqual(Boolean.MonoidXor.combineMany(false, [false]), false)
+      deepStrictEqual(Boolean.MonoidXor.combineMany(true, [true]), false)
+      deepStrictEqual(Boolean.MonoidXor.combineMany(true, [false]), true)
+      deepStrictEqual(Boolean.MonoidXor.combineMany(true, [true, false]), false)
+      deepStrictEqual(Boolean.MonoidXor.combineMany(true, [false, true]), false)
+      deepStrictEqual(Boolean.MonoidXor.combineAll([true, false]), true)
+      deepStrictEqual(Boolean.MonoidXor.combineAll([false, true]), true)
+    })
+
+    it("should handle iterables", () => {
+      deepStrictEqual(Boolean.MonoidXor.combineAll(new Set([true, true])), true)
+      deepStrictEqual(Boolean.MonoidXor.combineAll(new Set([true, false])), true)
+      deepStrictEqual(Boolean.MonoidXor.combineAll(new Set([false, false])), false)
+    })
+  })
+
+  describe.concurrent("MonoidEqv", () => {
+    it("baseline", () => {
+      deepStrictEqual(Boolean.MonoidEqv.combineMany(true, []), true)
+      deepStrictEqual(Boolean.MonoidEqv.combineMany(false, []), false)
+      deepStrictEqual(Boolean.MonoidEqv.combineMany(false, [true]), false)
+      deepStrictEqual(Boolean.MonoidEqv.combineMany(false, [false]), true)
+      deepStrictEqual(Boolean.MonoidEqv.combineMany(true, [true]), true)
+      deepStrictEqual(Boolean.MonoidEqv.combineMany(true, [false]), false)
+      deepStrictEqual(Boolean.MonoidEqv.combineMany(true, [true, false]), false)
+      deepStrictEqual(Boolean.MonoidEqv.combineMany(true, [false, true]), false)
+      deepStrictEqual(Boolean.MonoidEqv.combineAll([true, false]), false)
+      deepStrictEqual(Boolean.MonoidEqv.combineAll([false, true]), false)
+    })
+
+    it("should handle iterables", () => {
+      deepStrictEqual(Boolean.MonoidEqv.combineAll(new Set([true, true])), true)
+      deepStrictEqual(Boolean.MonoidEqv.combineAll(new Set([true, false])), false)
+      deepStrictEqual(Boolean.MonoidEqv.combineAll(new Set([false, false])), false)
     })
   })
 

--- a/test/Boolean.ts
+++ b/test/Boolean.ts
@@ -9,8 +9,16 @@ describe.concurrent("Boolean", () => {
     expect(Boolean.SemigroupAny).exist
     expect(Boolean.MonoidAny).exist
     expect(Boolean.SemigroupXor).exist
+    expect(Boolean.MonoidXor).exist
+    expect(Boolean.SemigroupEqv).exist
+    expect(Boolean.MonoidEqv).exist
     expect(Boolean.all).exist
     expect(Boolean.any).exist
+    expect(Boolean.xor).exist
+    expect(Boolean.eqv).exist
+    expect(Boolean.nand).exist
+    expect(Boolean.nor).exist
+    expect(Boolean.implies).exist
   })
 
   it("isBoolean", () => {

--- a/test/Boolean.ts
+++ b/test/Boolean.ts
@@ -8,6 +8,7 @@ describe.concurrent("Boolean", () => {
     expect(Boolean.MonoidAll).exist
     expect(Boolean.SemigroupAny).exist
     expect(Boolean.MonoidAny).exist
+    expect(Boolean.SemigroupExclusiveAny).exist
     expect(Boolean.all).exist
     expect(Boolean.any).exist
   })
@@ -26,6 +27,13 @@ describe.concurrent("Boolean", () => {
     deepStrictEqual(pipe(false, Boolean.and(false)), false)
   })
 
+  it("nand", () => {
+    deepStrictEqual(pipe(true, Boolean.nand(true)), false)
+    deepStrictEqual(pipe(true, Boolean.nand(false)), true)
+    deepStrictEqual(pipe(false, Boolean.nand(true)), true)
+    deepStrictEqual(pipe(false, Boolean.nand(false)), true)
+  })
+
   it("or", () => {
     deepStrictEqual(pipe(true, Boolean.or(true)), true)
     deepStrictEqual(pipe(true, Boolean.or(false)), true)
@@ -33,9 +41,48 @@ describe.concurrent("Boolean", () => {
     deepStrictEqual(pipe(false, Boolean.or(false)), false)
   })
 
+  it("nor", () => {
+    deepStrictEqual(pipe(true, Boolean.nor(true)), false)
+    deepStrictEqual(pipe(true, Boolean.nor(false)), false)
+    deepStrictEqual(pipe(false, Boolean.nor(true)), false)
+    deepStrictEqual(pipe(false, Boolean.nor(false)), true)
+  })
+
+  it("xor", () => {
+    deepStrictEqual(pipe(true, Boolean.xor(true)), false)
+    deepStrictEqual(pipe(true, Boolean.xor(false)), true)
+    deepStrictEqual(pipe(false, Boolean.xor(true)), true)
+    deepStrictEqual(pipe(false, Boolean.xor(false)), false)
+  })
+
+  it("xnor", () => {
+    deepStrictEqual(pipe(true, Boolean.xnor(true)), true)
+    deepStrictEqual(pipe(true, Boolean.xnor(false)), false)
+    deepStrictEqual(pipe(false, Boolean.xnor(true)), false)
+    deepStrictEqual(pipe(false, Boolean.xnor(false)), true)
+  })
+
+  it("implies", () => {
+    deepStrictEqual(pipe(true, Boolean.implies(true)), true)
+    deepStrictEqual(pipe(true, Boolean.implies(false)), false)
+    deepStrictEqual(pipe(false, Boolean.implies(true)), true)
+    deepStrictEqual(pipe(false, Boolean.implies(false)), true)
+  })
+
   it("not", () => {
     deepStrictEqual(pipe(true, Boolean.not), false)
     deepStrictEqual(pipe(false, Boolean.not), true)
+  })
+
+  describe.concurrent("SemigroupExclusiveAny", () => {
+    it("baseline", () => {
+      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(true, []), true)
+      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(false, []), false)
+      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(false, [true]), true)
+      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(false, [false]), false)
+      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(true, [true]), false)
+      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(true, [false]), true)
+    })
   })
 
   describe.concurrent("MonoidAll", () => {

--- a/test/Boolean.ts
+++ b/test/Boolean.ts
@@ -82,6 +82,8 @@ describe.concurrent("Boolean", () => {
       deepStrictEqual(Boolean.SemigroupXor.combineMany(false, [false]), false)
       deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [true]), false)
       deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [false]), true)
+      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [true, false]), false)
+      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [false, true]), false)
     })
   })
 

--- a/test/Boolean.ts
+++ b/test/Boolean.ts
@@ -8,7 +8,7 @@ describe.concurrent("Boolean", () => {
     expect(Boolean.MonoidAll).exist
     expect(Boolean.SemigroupAny).exist
     expect(Boolean.MonoidAny).exist
-    expect(Boolean.SemigroupExclusiveAny).exist
+    expect(Boolean.SemigroupXor).exist
     expect(Boolean.all).exist
     expect(Boolean.any).exist
   })
@@ -74,14 +74,14 @@ describe.concurrent("Boolean", () => {
     deepStrictEqual(pipe(false, Boolean.not), true)
   })
 
-  describe.concurrent("SemigroupExclusiveAny", () => {
+  describe.concurrent("SemigroupXor", () => {
     it("baseline", () => {
-      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(true, []), true)
-      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(false, []), false)
-      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(false, [true]), true)
-      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(false, [false]), false)
-      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(true, [true]), false)
-      deepStrictEqual(Boolean.SemigroupExclusiveAny.combineMany(true, [false]), true)
+      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, []), true)
+      deepStrictEqual(Boolean.SemigroupXor.combineMany(false, []), false)
+      deepStrictEqual(Boolean.SemigroupXor.combineMany(false, [true]), true)
+      deepStrictEqual(Boolean.SemigroupXor.combineMany(false, [false]), false)
+      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [true]), false)
+      deepStrictEqual(Boolean.SemigroupXor.combineMany(true, [false]), true)
     })
   })
 


### PR DESCRIPTION
# Pull Request Template

## Description

Add missing boolean combinators - like here https://mobily.github.io/ts-belt/api/boolean/
 - `nor`
 - `nand`
 - `xor`
 - `xnor`
 - `implies`

Add XorSemigroup - with name `Semigroup.booleanExclusiveAny` - use it in `xor` combinator

## Types of Changes

- [ ] Bugfix
- [x] New feature
- [ ] Documentation update

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/fp-ts/core/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have written tests for the changes I have made
- [x] I have run `pnpm coverage` and my code is 100% covered
- [x] I have updated the documentation (if applicable)
- [x] I agree to license my contribution under the MIT license

## Additional Information

Is there anything else you would like to add? Are there any questions that need to be answered before merging this pull request?
