### PR TITLE
Try to improve combineMany performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ yarn-error.log
 tmp/
 build/
 dist/
+.idea/

--- a/benchmark/combineMany.ts
+++ b/benchmark/combineMany.ts
@@ -1,0 +1,36 @@
+import { fromIterable } from "@fp-ts/core/internal/ReadonlyArray"
+import * as Benchmark from "benchmark"
+
+/*
+sumFromIterable x 24,899,792 ops/sec ±0.78% (88 runs sampled)
+sumIterable x 774,044,965 ops/sec ±1.63% (82 runs sampled)
+*/
+
+const suite = new Benchmark.Suite()
+
+const sumFromIterable = (self: number,collection: Iterable<number>): number => fromIterable(collection).reduce((a, b) => a + b, self)
+const sumIterable = (self: number, collection: Iterable<number>): number => {
+    let result = self;
+    for (const n of collection) {
+        result = result + n;
+    }
+    return result;
+}
+
+const testSelf = 0;
+const testCollection = new Set([1, 2, 3, 4, 5]);
+
+suite
+    .add("sumFromIterable", function() {
+        sumFromIterable(testSelf, testCollection)
+    })
+    .add("sumIterable", function() {
+        sumIterable(testSelf, testCollection)
+    })
+    .on("cycle", function(event: any) {
+        console.log(String(event.target))
+    })
+    .on("complete", function(this: any) {
+        console.log("Fastest is " + this.filter("fastest").map("name"))
+    })
+    .run({ async: true })

--- a/benchmark/combineMany.ts
+++ b/benchmark/combineMany.ts
@@ -2,30 +2,55 @@ import { fromIterable } from "@fp-ts/core/internal/ReadonlyArray"
 import * as Benchmark from "benchmark"
 
 /*
-sumFromIterable x 24,899,792 ops/sec ±0.78% (88 runs sampled)
-sumIterable x 774,044,965 ops/sec ±1.63% (82 runs sampled)
+Array:     sumFromIterable x 1,179,110 ops/sec ±0.45% (90 runs sampled)
+Array:     sumIterable     x 1,180,767 ops/sec ±0.47% (92 runs sampled)
+Set:       sumFromIterable x 281,417 ops/sec ±1.51% (83 runs sampled)
+Set:       sumIterable     x 439,688 ops/sec ±0.45% (93 runs sampled)
+Generator: sumFromIterable x 19,283 ops/sec ±1.75% (88 runs sampled)
+Generator: sumIterable     x 26,086 ops/sec ±0.72% (92 runs sampled)
 */
-
 const suite = new Benchmark.Suite()
 
-const sumFromIterable = (self: number,collection: Iterable<number>): number => fromIterable(collection).reduce((a, b) => a + b, self)
+const reducer = (a: number, b: number) => a + b
+const sumFromIterable = (self: number,collection: Iterable<number>): number => fromIterable(collection).reduce(reducer, self)
 const sumIterable = (self: number, collection: Iterable<number>): number => {
+    if(Array.isArray(collection)) {
+        return collection.reduce(reducer, self)
+    }
     let result = self;
     for (const n of collection) {
-        result = result + n;
+        result = reducer(result, n);
     }
     return result;
 }
 
 const testSelf = 0;
-const testCollection = new Set([1, 2, 3, 4, 5]);
+const testCollectionArray = Array.from({length:1000}).map((_,i) => i);
+const testCollectionSet = new Set(testCollectionArray);
+const testCollectionGenerator = function* (){
+    for (const n of testCollectionArray) {
+        yield n;
+    }
+};
 
 suite
-    .add("sumFromIterable", function() {
-        sumFromIterable(testSelf, testCollection)
+    .add("Array: sumFromIterable", function() {
+        sumFromIterable(testSelf, testCollectionArray)
     })
-    .add("sumIterable", function() {
-        sumIterable(testSelf, testCollection)
+    .add("Array: sumIterable", function() {
+        sumIterable(testSelf, testCollectionArray)
+    })
+    .add("Set: sumFromIterable", function() {
+        sumFromIterable(testSelf, testCollectionSet)
+    })
+    .add("Set: sumIterable", function() {
+        sumIterable(testSelf, testCollectionSet)
+    })
+    .add("Generator: sumFromIterable", function() {
+        sumFromIterable(testSelf, testCollectionGenerator())
+    })
+    .add("Generator: sumIterable", function() {
+        sumIterable(testSelf, testCollectionGenerator())
     })
     .on("cycle", function(event: any) {
         console.log(String(event.target))

--- a/benchmark/tsconfig.json
+++ b/benchmark/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": true,
     "module": "commonjs",
+    "downlevelIteration": true,
     "paths": {
       "@fp-ts/core": ["../src/index.ts"],
       "@fp-ts/core/test/*": ["../test/*"],

--- a/src/typeclass/Semigroup.ts
+++ b/src/typeclass/Semigroup.ts
@@ -3,7 +3,6 @@
  */
 import { dual } from "@fp-ts/core/Function"
 import type { TypeLambda } from "@fp-ts/core/HKT"
-import { fromIterable } from "@fp-ts/core/internal/ReadonlyArray"
 import type * as invariant from "@fp-ts/core/typeclass/Invariant"
 import type { Order } from "@fp-ts/core/typeclass/Order"
 import type * as product_ from "@fp-ts/core/typeclass/Product"
@@ -34,8 +33,13 @@ export interface SemigroupTypeLambda extends TypeLambda {
  */
 export const make = <A>(
   combine: Semigroup<A>["combine"],
-  combineMany: Semigroup<A>["combineMany"] = (self, collection) =>
-    fromIterable(collection).reduce(combine, self)
+  combineMany: Semigroup<A>["combineMany"] = (self, collection) => {
+    let result = self
+    for (const n of collection) {
+      result = combine(n, result)
+    }
+    return result
+  }
 ): Semigroup<A> => ({
   combine,
   combineMany


### PR DESCRIPTION
# Pull Request Template

## Description

Try to improve performance of `Semigroup.combineMany` default realization. 
In old implementation it's uses `Array.from` on `Iterable` - benchmarks shows what it's not optimal (because it's iterates twice - on creation of Array and on next reducing)
Stay old implementation for Array instances and use for-of for other instances.
I add several benchmarks - please look on it)

## Types of Changes

What types of changes does your code introduce to the library?

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation update

## Checklist

- [x] I have read the [contributing guidelines](https://github.com/fp-ts/core/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have written tests for the changes I have made
- [x] I have run `pnpm coverage` and my code is 100% covered
- [ ] I have updated the documentation (if applicable)
- [x] I agree to license my contribution under the MIT license

## Additional Information

Maybe it be usefull to have a Functor for Iterable - where this perf-complexity will be hidden?
