### PR TITLE
make `mapComposition` non-curried

### DIFF
--- a/docs/modules/typeclass/Covariant.ts.md
+++ b/docs/modules/typeclass/Covariant.ts.md
@@ -139,10 +139,9 @@ Returns a default `map` composition.
 export declare const mapComposition: <F extends TypeLambda, G extends TypeLambda>(
   F: Covariant<F>,
   G: Covariant<G>
-) => <A, B>(
+) => <FR, FO, FE, GR, GO, GE, A, B>(
+  self: Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, A>>,
   f: (a: A) => B
-) => <FR, FO, FE, GR, GO, GE>(
-  self: Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, A>>
 ) => Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, B>>
 ```
 

--- a/src/typeclass/Covariant.ts
+++ b/src/typeclass/Covariant.ts
@@ -24,11 +24,10 @@ export interface Covariant<F extends TypeLambda> extends Invariant<F> {
 export const mapComposition = <F extends TypeLambda, G extends TypeLambda>(
   F: Covariant<F>,
   G: Covariant<G>
-): (<A, B>(
+): (<FR, FO, FE, GR, GO, GE, A, B>(
+  self: Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, A>>,
   f: (a: A) => B
-) => <FR, FO, FE, GR, GO, GE>(
-  self: Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, A>>
-) => Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, B>>) => f => F.map(G.map(f))
+) => Kind<F, FR, FO, FE, Kind<G, GR, GO, GE, B>>) => (self, f) => F.map(self, G.map(f))
 
 /**
  * Returns a default `imap` implementation.

--- a/test/typeclass/Covariant.ts
+++ b/test/typeclass/Covariant.ts
@@ -8,11 +8,11 @@ describe("Covariant", () => {
   it("mapComposition", () => {
     const map = _.mapComposition(RA.Covariant, RA.Covariant)
     const f = (a: string) => a + "!"
-    U.deepStrictEqual(pipe([], map(f)), [])
-    U.deepStrictEqual(pipe([[]], map(f)), [[]])
-    U.deepStrictEqual(pipe([["a"]], map(f)), [["a!"]])
-    U.deepStrictEqual(pipe([["a"], ["b"]], map(f)), [["a!"], ["b!"]])
-    U.deepStrictEqual(pipe([["a", "c"], ["b", "d", "e"]], map(f)), [["a!", "c!"], [
+    U.deepStrictEqual(map([], f), [])
+    U.deepStrictEqual(map([[]], f), [[]])
+    U.deepStrictEqual(map([["a"]], f), [["a!"]])
+    U.deepStrictEqual(map([["a"], ["b"]], f), [["a!"], ["b!"]])
+    U.deepStrictEqual(map([["a", "c"], ["b", "d", "e"]], f), [["a!", "c!"], [
       "b!",
       "d!",
       "e!"


### PR DESCRIPTION
Other `*Composition` are not curried which seems to be more practical anyway so the `mapComposition` could be as well.